### PR TITLE
feat(authn): http token interceptor auto refreshes and replays

### DIFF
--- a/@kangaroo/angular-authn/src/oauth2/o-auth2-http-interceptor.spec.ts
+++ b/@kangaroo/angular-authn/src/oauth2/o-auth2-http-interceptor.spec.ts
@@ -22,6 +22,8 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { async, inject, TestBed } from '@angular/core/testing';
 import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { OAUTH2_API_ROOT, OAUTH2_CLIENT_ID, OAUTH2_CLIENT_SCOPES } from './contracts';
+import { OAuth2Service } from './o-auth2.service';
 
 /**
  * Unit tests for the OAuth2 Token Subject.
@@ -29,9 +31,18 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 describe('OAuth2HttpInterceptor', () => {
 
   let testSubject: BehaviorSubject<OAuth2Token>;
+  const testUrl = 'https://example.com'; // tslint:disable-line
   const nowInSeconds = Math.floor(Date.now() / 1000);
-  const validToken: OAuth2Token = {
-    access_token: 'access_token',
+  const validToken1: OAuth2Token = {
+    access_token: 'access_token_1',
+    refresh_token: 'refresh_token_1',
+    issue_date: nowInSeconds - 100,
+    expires_in: 3600,
+    token_type: 'Bearer'
+  };
+  const validToken2: OAuth2Token = {
+    access_token: 'access_token_2',
+    refresh_token: 'refresh_token_2',
     issue_date: nowInSeconds,
     expires_in: 3600,
     token_type: 'Bearer'
@@ -42,7 +53,11 @@ describe('OAuth2HttpInterceptor', () => {
     TestBed.configureTestingModule({
       providers: [
         {provide: HTTP_INTERCEPTORS, multi: true, useClass: OAuth2HttpInterceptor},
-        {provide: OAuth2TokenSubject, useValue: testSubject}
+        {provide: OAUTH2_API_ROOT, useValue: [ '' ]},
+        {provide: OAUTH2_CLIENT_ID, useValue: [ 'client_id' ]},
+        {provide: OAUTH2_CLIENT_SCOPES, useValue: [ [] ]},
+        {provide: OAuth2TokenSubject, useValue: testSubject},
+        OAuth2Service
       ],
       imports: [
         HttpClientTestingModule
@@ -52,9 +67,9 @@ describe('OAuth2HttpInterceptor', () => {
 
   it('should not provide a header if the token is null',
     async(inject([ HttpClient, HttpTestingController ], (client, http) => {
-      client.get('http://example.com').subscribe();
+      client.get(testUrl).subscribe();
 
-      const mockResponse = http.expectOne('http://example.com');
+      const mockResponse = http.expectOne(testUrl);
       expect(mockResponse.request.headers.has('Authorization')).toBeFalsy();
     })));
 
@@ -66,30 +81,98 @@ describe('OAuth2HttpInterceptor', () => {
         expires_in: 500,
         token_type: 'Bearer'
       });
-      client.get('http://example.com').subscribe();
+      client.get(testUrl).subscribe();
 
-      const mockResponse = http.expectOne('http://example.com');
+      const mockResponse = http.expectOne(testUrl);
       expect(mockResponse.request.headers.has('Authorization')).toBeFalsy();
     })));
 
   it('should not provide a header if the token is blank',
     async(inject([ HttpClient, HttpTestingController ], (client, http) => {
       testSubject.next(<any>{});
-      client.get('http://example.com').subscribe();
+      client.get(testUrl).subscribe();
 
-      const mockResponse = http.expectOne('http://example.com');
+      const mockResponse = http.expectOne(testUrl);
       expect(mockResponse.request.headers.has('Authorization')).toBeFalsy();
     })));
 
   it('should use the token "type value" format when creating the header',
     async(inject([ HttpClient, HttpTestingController ], (client, http) => {
-      testSubject.next(validToken);
-      client.get('http://example.com').subscribe();
+      testSubject.next(validToken1);
+      client.get(testUrl).subscribe();
 
-      const mockResponse = http.expectOne('http://example.com');
+      const mockResponse = http.expectOne(testUrl);
       expect(mockResponse.request.headers.has('Authorization')).toBeTruthy();
       expect(mockResponse.request.headers.get('Authorization'))
-        .toEqual(`${validToken.token_type} ${validToken.access_token}`);
+        .toEqual(`${validToken1.token_type} ${validToken1.access_token}`);
 
+    })));
+
+  it('should do nothing on a successful request',
+    async(inject([ HttpClient, HttpTestingController ], (client, http) => {
+      client.get(testUrl).subscribe((result) => expect(result).toBeDefined());
+      http.expectOne(testUrl).flush({}, {status: 200, statusText: 'OK'});
+      http.verify();
+    })));
+
+  it('should attempt to refresh a token if a 401 is detected.',
+    async(inject([ HttpClient, HttpTestingController, OAuth2TokenSubject ], (client, http, subject) => {
+      subject.next(validToken1);
+
+      // Kick off the initial request.
+      client.get(testUrl).subscribe((result) => expect(result).toBeDefined(), fail);
+      http.expectOne(testUrl).flush({}, {status: 401, statusText: 'OK'});
+      http.expectOne('/token').flush(validToken2);
+      http.expectOne(testUrl).flush({}, {status: 200, statusText: 'OK'});
+      http.verify();
+
+      expect(subject.value).toEqual(validToken2);
+    })));
+
+  it('should block multiple requests during a refresh cycle',
+    async(inject([ HttpClient, HttpTestingController, OAuth2TokenSubject ], (client, http, subject) => {
+      subject.next(validToken1);
+      client.get(testUrl).subscribe((result) => expect(result).toBeDefined(), fail);
+      http.expectOne(testUrl).error(null, {status: 401, statusText: 'Unauthorized'});
+      client.get(testUrl).subscribe((result) => expect(result).toBeDefined(), fail);
+      http.expectOne(testUrl).error(null, {status: 401, statusText: 'Unauthorized'});
+      http.expectOne('/token').flush(validToken2);
+      expect(subject.value).toEqual(validToken2);
+
+      const testRequests = http.match(testUrl);
+      expect(testRequests.length).toEqual(2);
+
+      testRequests.forEach((tr) => tr.flush({}, {status: 200, statusText: 'OK'}));
+      http.verify();
+    })));
+
+  it('should do nothing if a non-401 error is detected',
+    async(inject([ HttpClient, HttpTestingController, OAuth2TokenSubject ], (client, http, subject) => {
+      subject.next(validToken1);
+      client.get(testUrl).subscribe(fail, () => {});
+      http.expectOne(testUrl).error(null, {status: 400, statusText: 'Bad Request'});
+      http.verify();
+    })));
+
+  it('should do nothing if a 401 is detected, and there is no token',
+    async(inject([ HttpClient, HttpTestingController, OAuth2TokenSubject ], (client, http) => {
+      client.get(testUrl).subscribe(fail, () => {
+      });
+      http.expectOne(testUrl).error(null, {status: 401, statusText: 'Unauthorized'});
+      http.verify();
+    })));
+
+  it('should rethrow the original error if the refresh fails.',
+    async(inject([ HttpClient, HttpTestingController, OAuth2TokenSubject ], (client, http, subject) => {
+      subject.next(validToken1);
+      client.get(testUrl)
+        .subscribe(fail, (err) => {
+          expect(err.status).toEqual(401);
+        });
+
+      http.expectOne(testUrl).error({}, {status: 401, statusText: 'Unauthorized'});
+      http.expectOne('/token').error({}, {status: 400, statusText: 'Bad Request'});
+      expect(subject.value).toBeFalsy();
+      http.verify();
     })));
 });

--- a/@kangaroo/angular-authn/src/oauth2/o-auth2.service.ts
+++ b/@kangaroo/angular-authn/src/oauth2/o-auth2.service.ts
@@ -159,12 +159,15 @@ export class OAuth2Service {
 
       const refreshRequest = Observable
         .combineLatest(this.tokenRoot, refreshParams)
+        .first()
         .flatMap(([ url, params ]) => this.http.post<OAuth2Token>(url, params, {
           observe: 'body',
           headers: this.commonHeaders
         }))
-        .do((newToken) => this.subject.next(newToken))
         .first()
+        .do(
+          (newToken) => this.subject.next(newToken),
+          () => this.subject.next(null))
         .share();
 
       this.refreshRequests.set(token.refresh_token, refreshRequest);

--- a/@kangaroo/angular-authn/src/oauth2/require-logged-in.guard.ts
+++ b/@kangaroo/angular-authn/src/oauth2/require-logged-in.guard.ts
@@ -21,6 +21,7 @@ import { Observable } from 'rxjs/Observable';
 import { OAuth2TokenSubject } from './o-auth2-token.subject';
 import { Injectable } from '@angular/core';
 import 'rxjs/add/operator/filter';
+import { TokenUtil } from './util/token.util';
 
 /**
  * Ths route guard ensures that the user is correctly 'logged in'; i.e. has a valid token.
@@ -44,10 +45,6 @@ export class RequireLoggedInGuard implements CanActivate {
    * @return An observable, resolving to true if the token indicates the user is logged in.
    */
   public canActivate(): Observable<boolean> {
-    return this.tokenSubject
-      .map(t => {
-        const nowInSeconds = Math.floor(Date.now() / 1000);
-        return t != null && t.issue_date + t.expires_in > nowInSeconds;
-      });
+    return this.tokenSubject.map(t => TokenUtil.isValid(t));
   }
 }

--- a/@kangaroo/angular-authn/src/oauth2/require-logged-out.guard.ts
+++ b/@kangaroo/angular-authn/src/oauth2/require-logged-out.guard.ts
@@ -20,6 +20,7 @@ import { Observable } from 'rxjs/Observable';
 import { OAuth2TokenSubject } from './o-auth2-token.subject';
 import { Injectable } from '@angular/core';
 import 'rxjs/add/operator/filter';
+import { TokenUtil } from './util/token.util';
 
 /**
  * Ths route guard ensures that the user is currently logged out.
@@ -43,10 +44,6 @@ export class RequireLoggedOutGuard implements CanActivate {
    * @return An observable, resolving to true if the token indicates the user is logged out.
    */
   public canActivate(): Observable<boolean> {
-    return this.tokenSubject
-      .map(t => {
-        const nowInSeconds = Math.floor(Date.now() / 1000);
-        return t == null || t.issue_date + t.expires_in < nowInSeconds;
-      });
+    return this.tokenSubject.map(t => !TokenUtil.isValid(t));
   }
 }


### PR DESCRIPTION
If a 401 is encountered, and a token exists that can be refreshed, the refresh request will be
issued and the pending requests will be replayed with the new token.