### PR TITLE
feat(authn): token knows how old it is

### DIFF
--- a/@kangaroo/angular-authn/src/oauth2/index.ts
+++ b/@kangaroo/angular-authn/src/oauth2/index.ts
@@ -27,7 +27,9 @@ import { ModuleWithProviders, NgModule } from '@angular/core';
 import { OAuth2Service } from './o-auth2.service';
 import { OAUTH2_API_ROOT, OAUTH2_CLIENT_ID, OAUTH2_CLIENT_SCOPES } from './contracts';
 import { OAuth2TokenDetailsSubject } from './o-auth2-token-details.subject';
+import { LoggedInSubject } from './logged-in.subject';
 
+export { TokenUtil } from './util/token.util';
 export { OAuth2Token } from './model/o-auth2-token';
 export { OAuth2TokenDetails } from './model/o-auth2-token-details';
 export { OAuth2Service } from './o-auth2.service';
@@ -35,6 +37,7 @@ export { OAuth2TokenSubject } from './o-auth2-token.subject';
 export { OAuth2TokenDetailsSubject } from './o-auth2-token-details.subject';
 export { RequireLoggedInGuard } from './require-logged-in.guard';
 export { RequireLoggedOutGuard } from './require-logged-out.guard';
+export { LoggedInSubject } from './logged-in.subject';
 export * from './contracts';
 
 /**
@@ -52,7 +55,8 @@ export * from './contracts';
     RequireLoggedOutGuard,
     OAuth2TokenSubject,
     OAuth2TokenDetailsSubject,
-    OAuth2Service
+    OAuth2Service,
+    LoggedInSubject
   ]
 })
 export class KangarooOAuth2Module {

--- a/@kangaroo/angular-authn/src/oauth2/logged-in.subject.spec.ts
+++ b/@kangaroo/angular-authn/src/oauth2/logged-in.subject.spec.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { OAuth2TokenSubject } from './o-auth2-token.subject';
+import { async, inject, TestBed } from '@angular/core/testing';
+import { OAuth2Token } from './model/o-auth2-token';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { LoggedInSubject } from './logged-in.subject';
+
+/**
+ * Unit tests for the LoggedInSubject.
+ */
+describe('LoggedInSubject', () => {
+
+  const nowInSeconds = Math.floor(Date.now() / 1000);
+  const validToken: OAuth2Token = {
+    access_token: 'access_token_1',
+    refresh_token: 'refresh_token_1',
+    issue_date: nowInSeconds - 100,
+    expires_in: 3600,
+    token_type: 'Bearer'
+  };
+  const expiredToken: OAuth2Token = {
+    access_token: 'access_token_2',
+    refresh_token: 'refresh_token_2',
+    issue_date: nowInSeconds - 100,
+    expires_in: 50,
+    token_type: 'Bearer'
+  };
+  let tokenSubject: BehaviorSubject<OAuth2Token>;
+
+  beforeEach(() => {
+    tokenSubject = new BehaviorSubject<OAuth2Token>(validToken);
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: OAuth2TokenSubject, useValue: tokenSubject},
+        LoggedInSubject
+      ]
+    });
+  });
+
+  it('should construct', inject([ LoggedInSubject ], (subject) => {
+    expect(subject).toBeDefined();
+  }));
+
+  it('should be false if the token is expired', async(inject(
+    [ OAuth2TokenSubject, LoggedInSubject ], (token, loggedIn) => {
+      token.next(expiredToken);
+      loggedIn.subscribe((value) => expect(value).toEqual(false));
+    })));
+
+  it('should be false if the token is empty', async(inject(
+    [ OAuth2TokenSubject, LoggedInSubject ], (token, loggedIn) => {
+      token.next(null);
+      loggedIn.subscribe((value) => expect(value).toEqual(false));
+    })));
+
+  it('should be true if the token is valid', async(inject(
+    [ OAuth2TokenSubject, LoggedInSubject ], (token, loggedIn) => {
+      token.next(validToken);
+      loggedIn.subscribe((value) => expect(value).toEqual(true));
+    })));
+});

--- a/@kangaroo/angular-authn/src/oauth2/logged-in.subject.ts
+++ b/@kangaroo/angular-authn/src/oauth2/logged-in.subject.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { OAuth2TokenSubject } from './o-auth2-token.subject';
+import { Subscription } from 'rxjs/Subscription';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { TokenUtil } from './util/token.util';
+import { Injectable } from '@angular/core';
+
+/**
+ * Convenience injector. Are we logged in?
+ *
+ * @author Michael Krotscheck
+ */
+@Injectable()
+export class LoggedInSubject extends ReplaySubject<boolean> {
+
+  /**
+   * The details subscription.
+   */
+  private subscription: Subscription;
+
+  /**
+   * Create a new token subject.
+   */
+  constructor(public token: OAuth2TokenSubject) {
+    super(1);
+
+    this.subscription = token
+      .map((t) => TokenUtil.isValid(t))
+      .subscribe((value) => this.next(value));
+  }
+}

--- a/@kangaroo/angular-authn/src/oauth2/o-auth2-http-interceptor.spec.ts
+++ b/@kangaroo/angular-authn/src/oauth2/o-auth2-http-interceptor.spec.ts
@@ -32,7 +32,9 @@ describe('OAuth2HttpInterceptor', () => {
 
   let testSubject: BehaviorSubject<OAuth2Token>;
   const testUrl = 'https://example.com'; // tslint:disable-line
-  const nowInSeconds = Math.floor(Date.now() / 1000);
+  const now = new Date();
+  const nowInSeconds = Math.floor(now.getTime() / 1000);
+
   const validToken1: OAuth2Token = {
     access_token: 'access_token_1',
     refresh_token: 'refresh_token_1',
@@ -126,7 +128,7 @@ describe('OAuth2HttpInterceptor', () => {
       http.expectOne(testUrl).flush({}, {status: 200, statusText: 'OK'});
       http.verify();
 
-      expect(subject.value).toEqual(validToken2);
+      expect(subject.value.access_token).toEqual(validToken2.access_token);
     })));
 
   it('should block multiple requests during a refresh cycle',
@@ -137,7 +139,7 @@ describe('OAuth2HttpInterceptor', () => {
       client.get(testUrl).subscribe((result) => expect(result).toBeDefined(), fail);
       http.expectOne(testUrl).error(null, {status: 401, statusText: 'Unauthorized'});
       http.expectOne('/token').flush(validToken2);
-      expect(subject.value).toEqual(validToken2);
+      expect(subject.value.access_token).toEqual(validToken2.access_token);
 
       const testRequests = http.match(testUrl);
       expect(testRequests.length).toEqual(2);
@@ -149,7 +151,8 @@ describe('OAuth2HttpInterceptor', () => {
   it('should do nothing if a non-401 error is detected',
     async(inject([ HttpClient, HttpTestingController, OAuth2TokenSubject ], (client, http, subject) => {
       subject.next(validToken1);
-      client.get(testUrl).subscribe(fail, () => {});
+      client.get(testUrl).subscribe(fail, () => {
+      });
       http.expectOne(testUrl).error(null, {status: 400, statusText: 'Bad Request'});
       http.verify();
     })));

--- a/@kangaroo/angular-authn/src/oauth2/o-auth2-http-interceptor.ts
+++ b/@kangaroo/angular-authn/src/oauth2/o-auth2-http-interceptor.ts
@@ -72,6 +72,7 @@ export class OAuth2HttpInterceptor implements HttpInterceptor {
    * @returns The annotated request.
    */
   private addToken(req: HttpRequest<any>, token: OAuth2Token): HttpRequest<any> {
+    console.log(token);
     if (!TokenUtil.isValid(token)) {
       return req;
     }


### PR DESCRIPTION
In order to detect proper logged in state, we need to extract the HTTP response date and annotate
the returned token with that value. This permits the creation of a LoggedInSubject, which informst
the world whether the user is logged in.