### PR TITLE
feat(authn): import auth module and provide contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ Temporary Items
 */*/protractor
 */*/karma
 */*/tslint
+.ng_pkg_build

--- a/@kangaroo/angular-authn/src/index.ts
+++ b/@kangaroo/angular-authn/src/index.ts
@@ -16,5 +16,5 @@
  *
  */
 
-export * from './admin';
-export * from './oauth2';
+export * from './admin/index';
+export * from './oauth2/index';

--- a/@kangaroo/authz-ui/e2e/app.spec.ts
+++ b/@kangaroo/authz-ui/e2e/app.spec.ts
@@ -15,21 +15,20 @@
  * limitations under the License.
  *
  */
-import { AppPage } from './app.po';
+import { ApplicationPage } from './pages';
 
 /**
  * Smoke test for project configuration.
  */
 describe('Home page', () => {
-  const page: AppPage = new AppPage();
+  const app = new ApplicationPage();
 
-  beforeEach(() => {
-    page.navigateTo();
+  beforeEach(async () => {
+    await app.navigateTo();
   });
 
-  it('should display the header message', () => {
-    page
-      .getHeaderText()
-      .then((text) => expect(text).toEqual('Kangaroo: Administration'));
+  it('should display the header message', async () => {
+    const headerText = await app.getHeaderText();
+    expect(headerText).toEqual('Kangaroo: Administration');
   });
 });

--- a/@kangaroo/authz-ui/e2e/config/credentials.ts
+++ b/@kangaroo/authz-ui/e2e/config/credentials.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Michael Krotscheck
+ * Copyright (c) 2018 Michael Krotscheck
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -14,21 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { TestBed } from '@angular/core/testing';
-import { ApplicationModule } from './module';
 
 /**
- * Unit tests for the ApplicationModule
+ * This interface describes testing login credentials.
  */
-describe('ApplicationModule', () => {
+export interface Credentials {
+  /**
+   * User login.
+   */
+  login: string;
 
-  describe('module', () => {
-
-    it('should permit importing', () => {
-      TestBed.configureTestingModule(
-        {
-          imports: [ ApplicationModule ]
-        }).compileComponents();
-    });
-  });
-});
+  /**
+   * Password
+   */
+  password: string;
+}

--- a/@kangaroo/authz-ui/e2e/config/e2e-configuration.ts
+++ b/@kangaroo/authz-ui/e2e/config/e2e-configuration.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Michael Krotscheck
+ * Copyright (c) 2018 Michael Krotscheck
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -14,21 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { TestBed } from '@angular/core/testing';
-import { ApplicationModule } from './module';
+
+import { Credentials } from './credentials';
 
 /**
- * Unit tests for the ApplicationModule
+ * Common test configuration values.
  */
-describe('ApplicationModule', () => {
+export interface E2EConfiguration {
 
-  describe('module', () => {
-
-    it('should permit importing', () => {
-      TestBed.configureTestingModule(
-        {
-          imports: [ ApplicationModule ]
-        }).compileComponents();
-    });
-  });
-});
+  /**
+   * Default login credentials.
+   */
+  defaultCredentials: Credentials;
+}

--- a/@kangaroo/authz-ui/e2e/config/index.ts
+++ b/@kangaroo/authz-ui/e2e/config/index.ts
@@ -1,5 +1,6 @@
+import { E2EConfiguration } from './e2e-configuration';
 /*
- * Copyright (c) 2017 Michael Krotscheck
+ * Copyright (c) 2018 Michael Krotscheck
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -14,21 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { TestBed } from '@angular/core/testing';
-import { ApplicationModule } from './module';
 
 /**
- * Unit tests for the ApplicationModule
+ * Our test configuration.
  */
-describe('ApplicationModule', () => {
-
-  describe('module', () => {
-
-    it('should permit importing', () => {
-      TestBed.configureTestingModule(
-        {
-          imports: [ ApplicationModule ]
-        }).compileComponents();
-    });
-  });
-});
+export const config: E2EConfiguration = {
+  defaultCredentials: {
+    login: 'admin',
+    password: 'admin'
+  }
+};

--- a/@kangaroo/authz-ui/e2e/login.spec.ts
+++ b/@kangaroo/authz-ui/e2e/login.spec.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApplicationPage, LoginPage } from './pages';
+import { ProtractorUtil } from './util/protractor.util';
+import { browser, ElementFinder } from 'protractor';
+
+/**
+ * Login/logout page.
+ */
+describe('Login page', () => {
+  const application = new ApplicationPage();
+  const loginPage = new LoginPage();
+
+  beforeAll(async () => {
+    await application.navigateTo();
+  });
+
+  beforeEach(async () => {
+    await loginPage.navigateTo();
+  });
+
+  afterEach(async () => {
+    await ProtractorUtil.logout();
+  });
+
+  it('should render a login page', async () => {
+    await loginPage.navigateTo();
+
+    const loginField: ElementFinder = await loginPage.getLoginField();
+    const passwordField: ElementFinder = await loginPage.getPasswordField();
+    const submitButton: ElementFinder = await loginPage.getSubmitButton();
+
+    // Assert that the login field is focused.
+    const focused = await browser.driver.switchTo().activeElement();
+    expect(await focused.getAttribute('id')).toEqual('username_input');
+
+    // Assert that the form exists.
+    expect(await loginField.isPresent()).toBeTruthy();
+    expect(await passwordField.isPresent()).toBeTruthy();
+    expect(await submitButton.isPresent()).toBeTruthy();
+
+    // Assert that the submit button is disabled.
+    expect(await submitButton.getAttribute('disabled')).toBeTruthy();
+
+    // Enter login/password
+    await loginPage.setLogin('login');
+    await loginPage.setPassword('password');
+
+    // Assert that the submit button is enabled.
+    expect(await submitButton.getAttribute('disabled')).toBeFalsy();
+  });
+
+  it('should permit logging in', async () => {
+    await loginPage.navigateTo();
+
+    // Enter login/password
+    await loginPage.setLogin('admin');
+    await loginPage.setPassword('admin');
+
+    // Click submit
+    await loginPage.submit();
+
+    // Assert that we on the dashboard
+    expect(await browser.getCurrentUrl())
+      .toContain('/dashboard');
+
+    // Assert that we have a token in local storage.
+    const token = await browser.driver.executeScript(() => {
+      return window.localStorage.getItem('_kangaroo_token');
+    });
+    const decodedToken = JSON.parse(<string> token);
+    expect(decodedToken).toBeDefined();
+
+    // Assert that there's a logout button
+    const logoutButton = await application.getLogoutButton();
+    expect(await logoutButton.isPresent()).toBeTruthy();
+
+    // Click the logout button
+    await application.logout();
+
+    // Assert that we're on the login page.
+    expect(await browser.getCurrentUrl())
+      .toContain('/login');
+
+    // Assert that the token in localStorage is gone.
+    const deletedToken = await browser.driver.executeScript(() => {
+      return window.localStorage.getItem('_kangaroo_token');
+    });
+    expect(deletedToken).toBe('null');
+  });
+});

--- a/@kangaroo/authz-ui/e2e/pages/app.po.ts
+++ b/@kangaroo/authz-ui/e2e/pages/app.po.ts
@@ -15,35 +15,46 @@
  * limitations under the License.
  */
 
-import { browser, by, element } from 'protractor';
-import { By, promise, until } from 'selenium-webdriver';
+import { browser, by, element, ElementFinder } from 'protractor';
+import { ProtractorUtil } from '../util/protractor.util';
 
 /**
- * The root application page.
+ * The application page.
  */
-export class AppPage {
+export class ApplicationPage {
 
   /**
    * Navigate to the base application.
    *
    * @returns A control-flow-supporting promise.
    */
-  public navigateTo() {
-    const driver = browser.driver;
-    const url = browser.baseUrl;
-
-    return driver.getCurrentUrl()
-      .then((current) => current.indexOf(url) > -1)
-      .then((isLoaded) => <any> (isLoaded ? promise.fullyResolved(true) : driver.get(url)))
-      .then(() => driver.wait(until.elementLocated(By.css('kng-header'))))
-      .then((e) => driver.wait(until.elementIsVisible(e)))
-      .then(() => true);
+  public async navigateTo(): Promise<void> {
+    return ProtractorUtil.navigateTo(browser.baseUrl);
   }
 
   /**
    * Get the header text.
    */
-  public getHeaderText(): promise.Promise<string> {
+  public async getHeaderText(): Promise<string> {
     return element(by.css('kng-header #title')).getText();
+  }
+
+  /**
+   * Get a reference to the logout button.
+   *
+   * @returns The logout button. May not exist.
+   */
+  public async getLogoutButton(): Promise<ElementFinder> {
+    return element(by.id('logout_button'));
+  }
+
+  /**
+   * Get a reference to the logout button.
+   *
+   * @returns The logout button. May not exist.
+   */
+  public async logout(): Promise<void> {
+    const button = await this.getLogoutButton();
+    return button.click();
   }
 }

--- a/@kangaroo/authz-ui/e2e/pages/index.ts
+++ b/@kangaroo/authz-ui/e2e/pages/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Michael Krotscheck
+ * Copyright (c) 2018 Michael Krotscheck
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -14,21 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { TestBed } from '@angular/core/testing';
-import { ApplicationModule } from './module';
 
-/**
- * Unit tests for the ApplicationModule
- */
-describe('ApplicationModule', () => {
-
-  describe('module', () => {
-
-    it('should permit importing', () => {
-      TestBed.configureTestingModule(
-        {
-          imports: [ ApplicationModule ]
-        }).compileComponents();
-    });
-  });
-});
+export * from './app.po';
+export * from './login.po';

--- a/@kangaroo/authz-ui/e2e/pages/login.po.ts
+++ b/@kangaroo/authz-ui/e2e/pages/login.po.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RouterUtil } from '@kangaroo/devkit/protractor';
+import { By, element, ElementFinder } from 'protractor';
+
+/**
+ * The login page.
+ */
+export class LoginPage {
+
+  /**
+   * Navigate to the login page.
+   */
+  public async navigateTo(): Promise<any> {
+    return RouterUtil.navigateByUrl('/login');
+  }
+
+  /**
+   * Get the login field.
+   */
+  public async getLoginField(): Promise<ElementFinder> {
+    return element(By.id('username_input'));
+  }
+
+  /**
+   * Fill in the login form.
+   */
+  public async setLogin(login: string): Promise<void> {
+    const loginField: ElementFinder = await this.getLoginField();
+    return loginField.clear()
+      .then(() => loginField.sendKeys(login));
+  }
+
+  /**
+   * Get the password field.
+   */
+  public async getPasswordField(): Promise<ElementFinder> {
+    return element(By.id('password_input'));
+  }
+
+  /**
+   * Fill in the password form.
+   */
+  public async setPassword(password: string): Promise<void> {
+    const passwordField: ElementFinder = await this.getPasswordField();
+    return passwordField.clear()
+      .then(() => passwordField.sendKeys(password));
+  }
+
+  /**
+   * Get the submit button.
+   */
+  public async getSubmitButton(): Promise<ElementFinder> {
+    return element(By.id('login_button'));
+  }
+
+  /**
+   * Is the login button enabled?
+   */
+  public async isSubmitEnabled(): Promise<boolean> {
+    return (await this.getSubmitButton()).getAttribute('disabled')
+      .then((value) => !!value);
+  }
+
+  /**
+   * Click the login button.
+   */
+  public async submit(): Promise<void> {
+    return (await this.getSubmitButton()).click();
+  }
+
+  /**
+   * Get the error message
+   */
+  public async getErrorMessage(): Promise<string> {
+    return element(By.id('error_message')).getText();
+  }
+}

--- a/@kangaroo/authz-ui/e2e/tsconfig.e2e.json
+++ b/@kangaroo/authz-ui/e2e/tsconfig.e2e.json
@@ -4,7 +4,7 @@
     "outDir": "../out-tsc/e2e",
     "baseUrl": "./",
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2016",
     "types": [
       "jasmine",
       "jasminewd2",

--- a/@kangaroo/authz-ui/e2e/util/protractor.util.ts
+++ b/@kangaroo/authz-ui/e2e/util/protractor.util.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { browser } from 'protractor';
+import { By, until } from 'selenium-webdriver';
+
+/**
+ * This utility assists in managing login/logout sessions for the application.
+ */
+export class ProtractorUtil {
+
+  /**
+   * Destroy the current session, and reload the applicaiton.
+   */
+  public static async logout() {
+    // Flush the existing token.
+    await browser.executeScript(() => {
+      window.localStorage.removeItem('_kangaroo_token');
+    });
+    return ProtractorUtil.navigateTo(browser.baseUrl);
+  }
+
+  /**
+   * An angular-safe navigateTo method.
+   *
+   * @param url The url to navigate to.
+   * @returns {Promise<void>}
+   */
+  public static async navigateTo(url) {
+    const driver = browser.driver;
+    const currentUrl = await driver.getCurrentUrl();
+    if (currentUrl.indexOf(url) === -1) {
+      await browser.get(url);
+      const e = await driver.wait(until.elementLocated(By.css('kng-header')));
+      await driver.wait(until.elementIsVisible(e));
+    }
+  }
+}

--- a/@kangaroo/authz-ui/package.json
+++ b/@kangaroo/authz-ui/package.json
@@ -9,14 +9,14 @@
     "url": "https://krotscheck.net/"
   },
   "scripts": {
-    "prestart": "docker pull krotscheck/kangaroo-authz:latest && docker-compose up -d",
+    "prestart": "docker-compose up -d",
     "start": "ng serve --proxy-config proxy.conf.js --host 0.0.0.0",
     "build": "ng build --prod",
     "test": "ng test --code-coverage",
     "test.ci": "ng test --code-coverage -w false",
     "lint": "ng lint",
     "lint.ci": "ng lint --format checkstyle --force > ./reports/checkstyle-result.xml",
-    "e2e": "ng e2e",
+    "e2e": "ng e2e --proxy-config proxy.conf.js",
     "nsp": "nsp check ./"
   },
   "devDependencies": {

--- a/@kangaroo/authz-ui/src/modules/app/app.component.html
+++ b/@kangaroo/authz-ui/src/modules/app/app.component.html
@@ -15,5 +15,9 @@
   ~ limitations under the License.
   ~
   -->
-<kng-header></kng-header>
-<router-outlet></router-outlet>
+<div class="main-container">
+    <kng-header></kng-header>
+    <div class="content-container">
+        <router-outlet></router-outlet>
+    </div>
+</div>

--- a/@kangaroo/authz-ui/src/modules/app/header.component.html
+++ b/@kangaroo/authz-ui/src/modules/app/header.component.html
@@ -25,12 +25,11 @@
   <div class="header-nav">
   </div>
   <div class="header-actions">
-    <!--<a id="logout_button"-->
-       <!--class="nav-link nav-text"-->
-       <!--*ngIf="loggedIn"-->
-       <!--routerLink="/"-->
-       <!--(click)="logout()">-->
-      <!--Log Out-->
-    <!--</a>-->
+    <a id="logout_button"
+       class="nav-link nav-text"
+       *ngIf="loggedIn"
+       (click)="logout()">
+      Log Out
+    </a>
   </div>
 </header>

--- a/@kangaroo/authz-ui/src/modules/app/header.component.spec.ts
+++ b/@kangaroo/authz-ui/src/modules/app/header.component.spec.ts
@@ -16,26 +16,57 @@
  *
  */
 
-import { TestBed } from '@angular/core/testing';
+import { async, inject, TestBed } from '@angular/core/testing';
 import { HeaderComponent } from './header.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { By } from '@angular/platform-browser';
+import { LoggedInSubject, OAuth2Service, OAuth2Token, OAuth2TokenSubject } from '@kangaroo/angular-authn';
 import { ClrNavigationModule } from '@clr/angular';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { Observable } from 'rxjs/Observable';
 
 /**
  * Unit tests for the Header component.
  */
 describe('HeaderComponent', () => {
 
+  let loggedInSubject: BehaviorSubject<boolean>;
+  let tokenSubject: BehaviorSubject<OAuth2Token>;
+  let tokenService: OAuth2Service;
+
+  const nowInSeconds = Math.floor(Date.now() / 1000);
+  const validToken: OAuth2Token = {
+    access_token: 'access_token_1',
+    refresh_token: 'refresh_token_1',
+    issue_date: nowInSeconds - 100,
+    expires_in: 3600,
+    token_type: 'Bearer'
+  };
+
   beforeEach(() => {
 
+    loggedInSubject = new BehaviorSubject(true);
+    tokenSubject = new BehaviorSubject(validToken);
+    tokenService = <any> {
+      revoke: () => {
+      }
+    };
+
+
     TestBed.configureTestingModule({
+      providers: [
+        {provide: LoggedInSubject, useValue: loggedInSubject},
+        {provide: OAuth2TokenSubject, useValue: tokenSubject},
+        {provide: OAuth2Service, useValue: tokenService}
+      ],
       declarations: [
         HeaderComponent
       ],
       imports: [
         ClrNavigationModule,
-        RouterTestingModule
+        RouterTestingModule,
+        HttpClientTestingModule
       ]
     });
   });
@@ -51,4 +82,31 @@ describe('HeaderComponent', () => {
     expect(titleSpan).toBeDefined();
     expect(titleSpan.nativeElement.textContent).toContain('Kangaroo: Administration');
   });
+
+  it('should display a logout button when logged in, but not when logged out', async(inject(
+    [ LoggedInSubject ], (loggedIn) => {
+      const fixture = TestBed.createComponent(HeaderComponent);
+      loggedIn.next(false);
+      fixture.detectChanges();
+      fixture.whenStable()
+        .then(() => expect(fixture.componentInstance.loggedIn).toBeFalsy())
+        .then(() => fixture.debugElement.query(By.css('#logout_button')))
+        .then((element) => expect(element).toBeFalsy())
+        .then(() => loggedIn.next(true))
+        .then(() => fixture.detectChanges())
+        .then(() => fixture.whenStable())
+        .then(() => expect(fixture.componentInstance.loggedIn).toBeTruthy())
+        .then(() => fixture.debugElement.query(By.css('#logout_button')))
+        .then((element) => expect(element).toBeTruthy());
+    })));
+
+  it('should revoke the token on logout', async(inject(
+    [ OAuth2Service ], (service) => {
+      const spy = spyOn(service, 'revoke').and.returnValue(Observable.of([ true ]));
+      const fixture = TestBed.createComponent(HeaderComponent);
+      fixture.detectChanges();
+      fixture.whenStable()
+        .then(() => fixture.debugElement.query(By.css('#logout_button')).nativeElement.click())
+        .then(() => expect(spy).toHaveBeenCalledWith(validToken));
+    })));
 });

--- a/@kangaroo/authz-ui/src/modules/app/header.component.ts
+++ b/@kangaroo/authz-ui/src/modules/app/header.component.ts
@@ -17,7 +17,13 @@
  */
 
 import { Component } from '@angular/core';
+import { LoggedInSubject, OAuth2Service, OAuth2TokenSubject } from '@kangaroo/angular-authn';
 
+/**
+ * The application header.
+ *
+ * @author Michael Krotscheck
+ */
 @Component({
   selector: 'kng-header',
   templateUrl: './header.component.html'
@@ -25,8 +31,26 @@ import { Component } from '@angular/core';
 export class HeaderComponent {
 
   /**
+   * Is the user currently logged in?
+   */
+  public loggedIn = false;
+
+  /**
    * Create a new header component.
    */
-  constructor() {
+  constructor(public loggedInSubject: LoggedInSubject,
+              private tokenSubject: OAuth2TokenSubject,
+              private tokenService: OAuth2Service) {
+    this.loggedInSubject
+      .subscribe((li) => this.loggedIn = li);
+  }
+
+  /**
+   * Issue a token revocation request with the current token.
+   */
+  public logout() {
+    this.tokenSubject
+      .switchMap((token) => this.tokenService.revoke(token))
+      .subscribe();
   }
 }

--- a/@kangaroo/authz-ui/src/modules/app/module.ts
+++ b/@kangaroo/authz-ui/src/modules/app/module.ts
@@ -34,6 +34,8 @@ import { CannotConfigureComponent } from './configuration-failed/cannot-configur
 import { ConfigModule } from '../config';
 import { ErrorModule } from '../error';
 import { KangarooPlatformModule } from '@kangaroo/angular-platform';
+import { KangarooOAuth2Module } from '@kangaroo/angular-authn';
+import { LoginModule } from '../login';
 
 /**
  * This module contains all the components of the application shell, including header, configuration error cases,
@@ -51,7 +53,9 @@ import { KangarooPlatformModule } from '@kangaroo/angular-platform';
     ClrNavigationModule,
 
     ConfigModule,
-    ErrorModule
+    ErrorModule,
+    KangarooOAuth2Module,
+    LoginModule
   ],
   providers: [
     ConfigurationFailedGuard,

--- a/@kangaroo/authz-ui/src/modules/app/routes.ts
+++ b/@kangaroo/authz-ui/src/modules/app/routes.ts
@@ -20,6 +20,8 @@ import { Routes } from '@angular/router';
 import { ConfigurationFailedGuard } from './configuration-failed/configuration-failed.guard';
 import { ConfigurationSucceededGuard } from './configuration-failed/configuration-succeeded.guard';
 import { CannotConfigureComponent } from './configuration-failed/cannot-configure.component';
+import { NoopComponent } from '@kangaroo/angular-platform';
+import { RequireLoggedInGuard } from '@kangaroo/angular-authn';
 
 /**
  * Root application routes. Actual functional routes are provided by different modules.
@@ -27,12 +29,19 @@ import { CannotConfigureComponent } from './configuration-failed/cannot-configur
  * @author Michael Krotscheck
  */
 export const ROUTES: Routes = [
-  // {
-  //   path: '',
-  //   component: NoopComponent,
-  //   canActivate: [ ConfigurationSucceededGuard ],
-  //   canActivateChild: [ ConfigurationSucceededGuard ]
-  // },
+  {
+    path: '',
+    redirectTo: '/dashboard',
+    pathMatch: 'full'
+  },
+  {
+    path: 'dashboard',
+    component: NoopComponent,
+    canActivate: [
+      RequireLoggedInGuard,
+      ConfigurationSucceededGuard
+    ]
+  },
   {
     path: 'configuration-failed',
     component: CannotConfigureComponent,

--- a/@kangaroo/authz-ui/src/modules/config/angular-authn-contracts.spec.ts
+++ b/@kangaroo/authz-ui/src/modules/config/angular-authn-contracts.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { async, inject, TestBed } from '@angular/core/testing';
+import { KangarooConfigurationSubject } from './kangaroo-configuration.subject';
+import { AdminApiRoot } from './admin-api-root';
+import { BrowserModule } from '@angular/platform-browser';
+import { KangarooConfiguration } from './kangaroo-configuration';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { OAuthApiRoot } from './oauth-api-root';
+import {
+  adminApiRootProvider,
+  clientIdProvider,
+  clientScopesProvider,
+  oauthApiRootProvider
+} from './angular-authn-contracts';
+import { ADMIN_API_ROOT, OAUTH2_API_ROOT, OAUTH2_CLIENT_ID, OAUTH2_CLIENT_SCOPES } from '@kangaroo/angular-authn';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/zip';
+
+
+/**
+ * Unit tests for external contracts.
+ */
+describe('Contracts for @kangaroo/angular-authn', () => {
+
+  const mockConfigSubject = new ReplaySubject<KangarooConfiguration>();
+  const mockConfig: KangarooConfiguration = {
+    client: 'client_id',
+    scopes: [ 'scope-1', 'scope-2' ]
+  };
+
+  beforeEach(() => {
+    mockConfigSubject.next(mockConfig);
+
+    TestBed.configureTestingModule({
+      imports: [
+        BrowserModule
+      ],
+      providers: [
+        adminApiRootProvider,
+        oauthApiRootProvider,
+        clientIdProvider,
+        clientScopesProvider,
+
+        {provide: KangarooConfigurationSubject, useValue: mockConfigSubject},
+        AdminApiRoot,
+        OAuthApiRoot
+      ]
+    });
+  });
+
+  it('should provide ADMIN_API_ROOT', async(inject(
+    [ ADMIN_API_ROOT, AdminApiRoot ], (contract, root) => {
+      Observable
+        .zip(contract, root)
+        .subscribe(([ c, r ]) => expect(c).toEqual(r));
+    })));
+
+  it('should provide OAUTH2_API_ROOT', async(inject(
+    [ OAUTH2_API_ROOT, OAuthApiRoot ], (contract, root) => {
+      Observable
+        .zip(contract, root)
+        .subscribe(([ c, r ]) => expect(c).toEqual(r));
+    })));
+
+  it('should provide OAUTH2_CLIENT_ID', async(inject(
+    [ OAUTH2_CLIENT_ID, KangarooConfigurationSubject ], (contract, configSubject) => {
+      Observable
+        .zip(contract, configSubject)
+        .subscribe(([ c, config ]) => expect(c).toEqual(config.client));
+    })));
+
+  it('should provide OAUTH2_CLIENT_SCOPES', async(inject(
+    [ OAUTH2_CLIENT_SCOPES, KangarooConfigurationSubject ], (contract, configSubject) => {
+      Observable
+        .zip(contract, configSubject)
+        .subscribe(([ c, config ]) => expect(c).toEqual(config.scopes));
+    })));
+});

--- a/@kangaroo/authz-ui/src/modules/config/angular-authn-contracts.ts
+++ b/@kangaroo/authz-ui/src/modules/config/angular-authn-contracts.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FactoryProvider } from '@angular/core';
+import { KangarooConfigurationSubject } from './kangaroo-configuration.subject';
+import { OAuthApiRoot } from './oauth-api-root';
+import { ADMIN_API_ROOT, OAUTH2_API_ROOT, OAUTH2_CLIENT_ID, OAUTH2_CLIENT_SCOPES } from '@kangaroo/angular-authn';
+import { AdminApiRoot } from './admin-api-root';
+import { Observable } from 'rxjs/Observable';
+
+/**
+ * API Root factory.
+ *
+ * @param apiRoot The root provider.
+ * @returns The same root provider, under a different injection token.
+ */
+export function oauthApiRootFactory(apiRoot): Observable<string> {
+  return apiRoot;
+}
+
+/**
+ * Fulfill the auth module's /oauth2 root provider contract.
+ */
+export const oauthApiRootProvider: FactoryProvider = {
+  provide: OAUTH2_API_ROOT,
+  useFactory: oauthApiRootFactory,
+  deps: [ OAuthApiRoot ]
+};
+
+/**
+ * Client ID provider
+ *
+ * @param config The configuration provider.
+ * @returns A provider only for the client id.
+ */
+export function clientIdFactory(config: KangarooConfigurationSubject): Observable<string> {
+  return config.map((conf) => conf.client);
+}
+
+/**
+ * Fulfill the auth module's client id provider contract.
+ */
+export const clientIdProvider: FactoryProvider = {
+  provide: OAUTH2_CLIENT_ID,
+  useFactory: clientIdFactory,
+  deps: [ KangarooConfigurationSubject ]
+};
+
+/**
+ * Client Scopes provider
+ *
+ * @param config The configuration provider.
+ * @returns A provider only for the client scopes.
+ */
+export function clientScopesFactory(config: KangarooConfigurationSubject): Observable<string[]> {
+  return config.map((conf) => conf.scopes);
+}
+
+/**
+ * Fulfill the client scopes provider contract.
+ */
+export const clientScopesProvider: FactoryProvider = {
+  provide: OAUTH2_CLIENT_SCOPES,
+  useFactory: clientScopesFactory,
+  deps: [ KangarooConfigurationSubject ]
+};
+
+/**
+ * Client Scopes provider
+ *
+ * @param apiRoot The injected admin api root.
+ * @returns That same API root, under a different injection token.
+ */
+export function adminApiRootFactory(apiRoot): Observable<string> {
+  return apiRoot;
+}
+
+/**
+ * Fulfill the admin api root provider contract.
+ */
+export const adminApiRootProvider: FactoryProvider = {
+  provide: ADMIN_API_ROOT,
+  useFactory: adminApiRootFactory,
+  deps: [ AdminApiRoot ]
+};

--- a/@kangaroo/authz-ui/src/modules/config/module.ts
+++ b/@kangaroo/authz-ui/src/modules/config/module.ts
@@ -20,6 +20,12 @@ import { KangarooConfigurationSubject } from './kangaroo-configuration.subject';
 import { AdminApiRoot } from './admin-api-root';
 import { OAuthApiRoot } from './oauth-api-root';
 import { HttpClientModule } from '@angular/common/http';
+import {
+  adminApiRootProvider,
+  clientIdProvider,
+  clientScopesProvider,
+  oauthApiRootProvider
+} from './angular-authn-contracts';
 
 /**
  * This module handles system configuration, environment detection, and all related
@@ -31,7 +37,12 @@ import { HttpClientModule } from '@angular/common/http';
   providers: [
     KangarooConfigurationSubject,
     AdminApiRoot,
-    OAuthApiRoot
+    OAuthApiRoot,
+
+    adminApiRootProvider,
+    oauthApiRootProvider,
+    clientIdProvider,
+    clientScopesProvider
   ],
   imports: [
     HttpClientModule

--- a/@kangaroo/authz-ui/src/modules/login/index.spec.ts
+++ b/@kangaroo/authz-ui/src/modules/login/index.spec.ts
@@ -14,20 +14,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as all from './index';
+import { LoginModule } from './index';
 import { TestBed } from '@angular/core/testing';
-import { ApplicationModule } from './module';
 
 /**
- * Unit tests for the ApplicationModule
+ * Unit tests for the LoginModule
  */
-describe('ApplicationModule', () => {
+describe('LoginModule', () => {
+
+  const expectedExports = [
+    'LoginModule'
+  ];
+
+  expectedExports.forEach((name) => {
+    it(`should export ${name}`, () => {
+      expect(all.hasOwnProperty(name)).toBeTruthy();
+    });
+  });
+
+  it('should only export expected properties', () => {
+    Object.keys(all).forEach((name) => {
+      expect(expectedExports.indexOf(name)).not.toEqual(-1, `Unexpected export found: ${name}`);
+    });
+  });
 
   describe('module', () => {
 
     it('should permit importing', () => {
       TestBed.configureTestingModule(
         {
-          imports: [ ApplicationModule ]
+          imports: [ LoginModule ],
+          providers: []
         }).compileComponents();
     });
   });

--- a/@kangaroo/authz-ui/src/modules/login/index.ts
+++ b/@kangaroo/authz-ui/src/modules/login/index.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { ROUTES } from './routes';
+import { LoginComponent } from './login.component';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { ConfigModule } from '../config';
+import { KangarooOAuth2Module } from '@kangaroo/angular-authn';
+
+/**
+ * This module handles the login pages, as well as the route-guards and services necessary
+ * to perform a login.
+ *
+ * @author Michael Krotscheck
+ */
+@NgModule({
+  declarations: [
+    LoginComponent
+  ],
+  imports: [
+    CommonModule,
+    RouterModule,
+    FormsModule,
+    ConfigModule,
+    KangarooOAuth2Module,
+    RouterModule.forChild(ROUTES)
+  ],
+  exports: [
+    RouterModule
+  ]
+})
+export class LoginModule {
+}

--- a/@kangaroo/authz-ui/src/modules/login/login.component.html
+++ b/@kangaroo/authz-ui/src/modules/login/login.component.html
@@ -1,0 +1,81 @@
+<!--
+  ~ Copyright (c) 2018 Michael Krotscheck
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy
+  ~ of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<div class="content-area">
+    <h1>Login</h1>
+    <form #loginForm="ngForm">
+        <section class="form-block">
+            <div class="form-group">
+                <label for="username_input">Username</label>
+                <label for="username_input"
+                       role="tooltip"
+                       class="tooltip tooltip-validation tooltip-md"
+                       [class.invalid]="usernameModel.invalid && (usernameModel.dirty || usernameModel.touched)">
+                    <input id="username_input"
+                           #usernameInput
+                           name="username_input"
+                           type="text"
+                           size="50"
+                           [(ngModel)]="username"
+                           (keyup.enter)="loginForm.valid && login()"
+                           #usernameModel="ngModel"
+                           [disabled]="loading"
+                           required>
+                    <span class="tooltip-content">
+                    Username is required.
+                </span>
+                </label>
+            </div>
+            <div class="form-group">
+                <label for="password_input">Password</label>
+                <label for="password_input"
+                       role="tooltip"
+                       class="tooltip tooltip-validation tooltip-md"
+                       [class.invalid]="passwordInput.invalid && (passwordInput.dirty || passwordInput.touched)">
+                    <input id="password_input"
+                           name="password_input"
+                           type="text"
+                           size="50"
+                           [(ngModel)]="password"
+                           #passwordInput="ngModel"
+                           (keyup.enter)="loginForm.valid && login()"
+                           [disabled]="loading"
+                           required>
+                    <span class="tooltip-content">
+                    Password is required.
+                </span>
+                </label>
+            </div>
+            <div class="form-group">
+                <button id="login_button"
+                        type="button"
+                        [disabled]="loginForm.invalid || loading"
+                        class="btn btn-primary"
+                        (click)="login()">
+                    Login
+                </button>
+            </div>
+            <div class="form-group" *ngIf="errored">
+                <div id="error_message" class="alert alert-danger">
+                    <div class="alert-items">
+                        <div class="alert-item text-center">Your login credentials are incorrect. Please try again.
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </form>
+</div>

--- a/@kangaroo/authz-ui/src/modules/login/login.component.spec.ts
+++ b/@kangaroo/authz-ui/src/modules/login/login.component.spec.ts
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { async, ComponentFixture, inject, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms';
+import { OAuth2Service, OAuth2Token, OAuth2TokenSubject } from '@kangaroo/angular-authn';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Router } from '@angular/router';
+import { LoginComponent } from './login.component';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { Observable } from 'rxjs/Observable';
+
+/**
+ * Unit tests for the Login form component.
+ */
+describe('LoginComponent', () => {
+
+  let loggedInSubject: BehaviorSubject<boolean>;
+  let tokenSubject: BehaviorSubject<OAuth2Token>;
+  let tokenService: OAuth2Service;
+  let fixture: ComponentFixture<LoginComponent>;
+
+  const nowInSeconds = Math.floor(Date.now() / 1000);
+  const validToken: OAuth2Token = {
+    access_token: 'access_token_1',
+    refresh_token: 'refresh_token_1',
+    issue_date: nowInSeconds - 100,
+    expires_in: 3600,
+    token_type: 'Bearer'
+  };
+
+  beforeEach(() => {
+
+    loggedInSubject = new BehaviorSubject(true);
+    tokenSubject = new BehaviorSubject(validToken);
+    tokenService = <any> {
+      login: () => {
+      }
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: OAuth2TokenSubject, useValue: tokenSubject},
+        {provide: OAuth2Service, useValue: tokenService}
+      ],
+      declarations: [
+        LoginComponent
+      ],
+      imports: [
+        FormsModule,
+        RouterTestingModule
+      ]
+    });
+
+    fixture = TestBed.createComponent(LoginComponent);
+  });
+
+  it('should construct', () => {
+    expect(fixture).toBeDefined();
+  });
+
+  it('should contain a login form', () => {
+    const usernameInput = fixture.debugElement.query(By.css('#username_input'));
+    const passwordInput = fixture.debugElement.query(By.css('#password_input'));
+    const loginButton = fixture.debugElement.query(By.css('#login_button'));
+
+    expect(usernameInput).toBeDefined();
+    expect(passwordInput).toBeDefined();
+    expect(loginButton).toBeDefined();
+  });
+
+  it('should disable the button when the fields are empty', async(() => {
+    fixture.detectChanges();
+    fixture.whenStable()
+      .then(() => {
+        fixture.detectChanges();
+        return fixture.whenStable();
+      })
+      .then(() => {
+        const loginButton = fixture.debugElement.query(By.css('#login_button'));
+        expect(loginButton.nativeElement.attributes[ 'disabled' ]).toBeDefined();
+
+        fixture.componentInstance.username = 'login';
+        fixture.componentInstance.password = 'password';
+        fixture.detectChanges();
+        return fixture.whenStable();
+      })
+      .then(() => {
+        // Apparently, forms require a double wait check here.
+        fixture.detectChanges();
+        return fixture.whenStable();
+      })
+      .then(() => {
+        const loginButton = fixture.debugElement.query(By.css('#login_button'));
+        expect(loginButton.nativeElement.attributes[ 'disabled' ]).not.toBeDefined();
+      });
+  }));
+
+  it('should automatically focus on the login input', () => {
+
+    fixture.whenStable()
+      .then(() => fixture.detectChanges())
+      .then(() => {
+        const usernameInput = fixture.debugElement.query(By.css('#username_input:focus'));
+        expect(usernameInput.nativeElement).toBeDefined();
+      });
+  });
+
+  it('should invoke the login method when clicked', () => {
+    const controller: LoginComponent = fixture.componentInstance;
+    const loginSpy: jasmine.Spy = spyOn(controller, 'login').and.stub();
+
+    controller.username = 'login';
+    controller.password = 'password';
+
+    const loginButton = fixture.debugElement.query(By.css('#login_button'));
+
+    fixture.detectChanges();
+
+    fixture.whenStable()
+      .then(() => fixture.detectChanges())
+      .then(() => loginButton.nativeElement.click())
+      .then(() => {
+        expect(loginSpy).toHaveBeenCalled();
+      });
+  });
+
+  it('should disable the form when the loading flag is set', async(() => {
+    const controller: LoginComponent = fixture.componentInstance;
+    controller.loading = true;
+
+    fixture.detectChanges();
+
+    fixture.whenStable()
+      .then(() => {
+        const usernameInput = fixture.debugElement.query(By.css('#username_input:disabled'));
+        expect(usernameInput.nativeElement).toBeDefined();
+        const passwordInput = fixture.debugElement.query(By.css('#password_input:disabled'));
+        expect(passwordInput.nativeElement).toBeDefined();
+        const loginButton = fixture.debugElement.query(By.css('#login_button:disabled'));
+        expect(loginButton.nativeElement).toBeDefined();
+      });
+  }));
+
+  it('should display an error when the error flag is set', async(() => {
+    const controller: LoginComponent = fixture.componentInstance;
+    controller.errored = true;
+
+    fixture.detectChanges();
+
+    fixture.whenStable()
+      .then(() => {
+        const errorMessage = fixture.debugElement.query(By.css('.alert.alert-danger'));
+        expect(errorMessage.nativeElement).toBeDefined();
+      });
+  }));
+
+  it('should not display an error when the error flag is not set', async(() => {
+    const controller: LoginComponent = fixture.componentInstance;
+    controller.errored = false;
+
+    fixture.detectChanges();
+
+    fixture.whenStable()
+      .then(() => {
+        const errorMessage = fixture.debugElement.query(By.css('.alert.alert-danger'));
+        expect(errorMessage).toBeNull();
+      });
+  }));
+
+  it('should permit submitting the form with enter in the username field if form valid', async(() => {
+    const controller: LoginComponent = fixture.componentInstance;
+    const loginSpy: jasmine.Spy = spyOn(controller, 'login').and.stub();
+
+    controller.username = 'login';
+    controller.password = 'password';
+    const usernameInput = fixture.debugElement.query(By.css('#username_input'));
+
+    fixture.detectChanges();
+
+    fixture.whenStable()
+      .then(() => usernameInput.triggerEventHandler('keyup.enter', {}))
+      .then(() => {
+        expect(loginSpy).toHaveBeenCalled();
+      });
+  }));
+
+  it('should not permit submitting the form with enter in the username field if form invalid', async(() => {
+    const controller: LoginComponent = fixture.componentInstance;
+    const loginSpy: jasmine.Spy = spyOn(controller, 'login').and.stub();
+
+    controller.username = '';
+    controller.password = 'password';
+    const usernameInput = fixture.debugElement.query(By.css('#username_input'));
+
+    fixture.detectChanges();
+
+    fixture.whenStable()
+      .then(() => usernameInput.triggerEventHandler('keyup.enter', {}))
+      .then(() => {
+        expect(loginSpy).not.toHaveBeenCalled();
+      });
+  }));
+
+  it('should permit submitting the form with enter in the password field if form valid', async(() => {
+    const controller: LoginComponent = fixture.componentInstance;
+    const loginSpy: jasmine.Spy = spyOn(controller, 'login').and.stub();
+
+    controller.username = 'login';
+    controller.password = 'password';
+    const passwordInput = fixture.debugElement.query(By.css('#password_input'));
+
+    fixture.detectChanges();
+
+    fixture.whenStable()
+      .then(() => passwordInput.triggerEventHandler('keyup.enter', {}))
+      .then(() => {
+        expect(loginSpy).toHaveBeenCalled();
+      });
+  }));
+
+  it('should not permit submitting the form with enter in the password field if form invalid', async(() => {
+    const controller: LoginComponent = fixture.componentInstance;
+    const loginSpy: jasmine.Spy = spyOn(controller, 'login').and.stub();
+
+    controller.username = '';
+    controller.password = 'password';
+    const passwordInput = fixture.debugElement.query(By.css('#password_input'));
+
+    fixture.detectChanges();
+
+    fixture.whenStable()
+      .then(() => passwordInput.triggerEventHandler('keyup.enter', {}))
+      .then(() => {
+        expect(loginSpy).not.toHaveBeenCalled();
+      });
+  }));
+
+  it('should show an error on a form submission failure', async(inject(
+    [ OAuth2Service ], (service) => {
+      const controller: LoginComponent = fixture.componentInstance;
+      spyOn(service, 'login').and.returnValue(Observable.throw('failed'));
+      controller.username = 'login';
+      controller.password = 'password';
+      fixture.debugElement.query(By.css('#login_button')).nativeElement.click();
+
+      // This resolves immediately.
+      expect(controller.errored).toBeTruthy();
+      expect(controller.loading).toBeFalsy();
+
+      const errorMessage = fixture.debugElement.query(By.css('#error_message'));
+      expect(errorMessage).toBeDefined();
+    })));
+
+  it('should navigate to the dashboard on a successful login', async(inject(
+    [ OAuth2Service, Router ], (service, router) => {
+      const controller: LoginComponent = fixture.componentInstance;
+      spyOn(service, 'login').and.returnValue(Observable.from([ true ]));
+      const routerSpy = spyOn(router, 'navigate').and.callThrough();
+      controller.username = 'login';
+      controller.password = 'password';
+      fixture.debugElement.query(By.css('#login_button')).nativeElement.click();
+
+      // This resolves immediately.
+      expect(controller.errored).toBeFalsy();
+      expect(controller.loading).toBeFalsy();
+
+      const errorMessage = fixture.debugElement.query(By.css('#error_message'));
+      expect(errorMessage).toBeNull();
+
+      expect(routerSpy).toHaveBeenCalledWith([ '' ]);
+    })));
+});

--- a/@kangaroo/authz-ui/src/modules/login/login.component.ts
+++ b/@kangaroo/authz-ui/src/modules/login/login.component.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AfterViewInit, Component, ElementRef, ViewChild } from '@angular/core';
+import { Router } from '@angular/router';
+import { OAuth2TokenSubject } from '@kangaroo/angular-authn';
+import { OAuth2Service } from '@kangaroo/angular-authn';
+
+/**
+ * This component renders the login form.
+ *
+ * @author Michael Krotscheck
+ */
+@Component({
+  templateUrl: './login.component.html'
+})
+export class LoginComponent implements AfterViewInit {
+
+  /**
+   *  This variable contains the username input in the form.
+   *
+   * @type {string}
+   */
+  public username = '';
+
+  /**
+   * This variable contains the password input into the form.
+   * @type {string}
+   */
+  public password = '';
+
+  /**
+   * Did the last login error?
+   *
+   * @type {boolean}
+   */
+  public errored = false;
+
+  /**
+   * Are we currently loading?
+   *
+   * @type {boolean}
+   */
+  public loading = false;
+
+  /**
+   * The username input field.
+   */
+  @ViewChild('usernameInput')
+  public usernameInput: ElementRef;
+
+  /**
+   * Create a new instance of this component.
+   *
+   * @param {OAuth2Service} oauth2 The login service.
+   * @param {OAuth2TokenSubject} oauth2Token The OAuth2 Token subject.
+   * @param {Router} router The router.
+   */
+  constructor(private oauth2: OAuth2Service,
+              private oauth2Token: OAuth2TokenSubject,
+              private router: Router) {
+  }
+
+  /**
+   * After view init, focus the login field.
+   */
+  ngAfterViewInit(): void {
+    this.usernameInput.nativeElement.focus();
+  }
+
+  /**
+   * Login the user.
+   */
+  public login() {
+    this.errored = false;
+    this.loading = true;
+    this.oauth2
+      .login(this.username, this.password)
+      .finally(() => this.loading = false)
+      .subscribe(
+        () => this.router.navigate(['']),
+        () => this.errored = true
+      );
+  }
+}

--- a/@kangaroo/authz-ui/src/modules/login/routes.ts
+++ b/@kangaroo/authz-ui/src/modules/login/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Michael Krotscheck
+ * Copyright (c) 2018 Michael Krotscheck
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -14,21 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { TestBed } from '@angular/core/testing';
-import { ApplicationModule } from './module';
+
+import { RequireLoggedOutGuard } from '@kangaroo/angular-authn';
+import { LoginComponent } from './login.component';
+import { ConfigurationSucceededGuard } from '../app/configuration-failed/configuration-succeeded.guard';
+import { Routes } from '@angular/router';
+
 
 /**
- * Unit tests for the ApplicationModule
+ * All routes used by the login module.
+ *
+ * @author Michael Krotscheck
  */
-describe('ApplicationModule', () => {
-
-  describe('module', () => {
-
-    it('should permit importing', () => {
-      TestBed.configureTestingModule(
-        {
-          imports: [ ApplicationModule ]
-        }).compileComponents();
-    });
-  });
-});
+export const ROUTES: Routes = [
+  {
+    path: 'login',
+    component: LoginComponent,
+    canActivate: [
+      RequireLoggedOutGuard,
+      ConfigurationSucceededGuard
+    ]
+  }
+];


### PR DESCRIPTION
This patch provides the contracts for the kangaroo authn module, and imports the same. It
then uses those contracts to create a basic login experience, as well as the necessary
unit and functional tests to validate it.