### PR TITLE
ci(8080): lock port 8080 so multiple builds don't conflict

### DIFF
--- a/@kangaroo/authz-ui/package.json
+++ b/@kangaroo/authz-ui/package.json
@@ -21,8 +21,7 @@
   },
   "devDependencies": {
     "@angular/cli": "~1.7.4",
-    "@kangaroo/devkit": "~1.0.0",
-    "wsrun": "~2.1.1"
+    "@kangaroo/devkit": "~1.0.0"
   },
   "dependencies": {
     "@angular/animations": "~5.2.9",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,9 +63,11 @@ pipeline {
          */
         stage('E2E') {
             steps {
-                script {
-                    docker.image('krotscheck/kangaroo-authz:latest').withRun("-p 8080:8080") {
-                        sh('yarn workspace @kangaroo/authz-ui e2e')
+                lock(resource: "${NODE_NAME}_port_8080") {
+                    script {
+                        docker.image('krotscheck/kangaroo-authz:latest').withRun("-p 8080:8080") {
+                            sh('yarn workspace @kangaroo/authz-ui e2e')
+                        }
                     }
                 }
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8794,7 +8794,7 @@ ws@~3.3.1:
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
-wsrun@2.1.1, wsrun@~2.1.1:
+wsrun@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/wsrun/-/wsrun-2.1.1.tgz#36efb867402990e25560c815e18b6440b6a9e1b3"
   dependencies:


### PR DESCRIPTION
This removes an old dependency, and adds resource locking of ports on a per-worker basis.