### PR TITLE
ci(ci): use nodejs label to declare build worker

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
 
 pipeline {
 
-    agent { label 'worker' }
+    agent { label 'nodejs' }
 
     options {
         buildDiscarder(logRotator(numToKeepStr: '10'))


### PR DESCRIPTION
Instead of using the generic 'worker' tag, this selects by available tool